### PR TITLE
fix GitHub Enterprise Identify Provider to work with keycloak 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Project that contains extensions to the Keycloak auth server.
 
 ## Social Connectors
 This project contains two custom Keycloak identity providers, one for GitHub Enterprise and one for
-GitLab (local).  As of version 6, Keycloak does not have support for locally installed versions of 
+GitLab (local).  As of version 9, Keycloak does not have support for locally installed versions of
 GitHub and GitLab beyond the standard **OpenID Connect v1.0** connector.  This connector does not
-work well for GitLab and not at all for GitHub Enteprise.  The **social** module found in this
+work well for GitLab and not at all for GitHub Enterprise.  The **social** module found in this
 repository corrects this by providing GitHub and GitLab specific identity providers that can be
 configured to point to local installations.
 
@@ -19,7 +19,7 @@ For more information about why this provider is necessary, see [this issue](http
 The following are steps to using this provider:
 
 1. Clone and build the custom Keycloak provider here:  https://github.com/Apicurio/apicurio-keycloak-extensions
-2. Copy the resulting JAR file from `apicurio-keycloak-extensions/social/target/apicurio-keycloak-extensions-social-1.0.0-SNAPSHOT.jar` into your Keycloak installation's `standalone/deployments` directory
+2. Copy the resulting JAR file from `apicurio-keycloak-extensions/social/target/apicurio-keycloak-extensions-social-9.0.0-SNAPSHOT.jar` into your Keycloak installation's `standalone/deployments` directory
 3. Before starting Keycloak, add the following system property:  `-Dapicurio.hub.gitlab.url=http://local-gitlab.example.org` where the value is obviously the real URL to your local GitLab install
 4. When configuring Keycloak, you will now have two *GitLab* options when creating the Identity Provider.  Instead of choosing *GitLab* (or *OpenID Connect v1.0*) instead choose **GitLab (Local)**.
 5. All other configuration is the same as documented for using the public GitLab service.
@@ -41,7 +41,7 @@ For more information about why this provider is necessary, see [this issue](http
 The following are steps to using this provider:
 
 1. Clone and build the custom Keycloak provider(s) here: https://github.com/Apicurio/apicurio-keycloak-extensions
-2. Copy the resulting JAR file from `apicurio-keycloak-extensions/social/target/apicurio-keycloak-extensions-social-6.0.0-SNAPSHOT.jar` into your Keycloak installation's `standalone/deployments` directory
+2. Copy the resulting JAR file from `apicurio-keycloak-extensions/social/target/apicurio-keycloak-extensions-social-9.0.0-SNAPSHOT.jar` into your Keycloak installation's `standalone/deployments` directory
 3. Before starting Keycloak, add the following two system properties to it (either via command line or via standalone.xml):
 ```
 -Dapicurio.hub.github.baseUrl=https://github.com

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following are steps to using this provider:
 -Dapicurio.hub.github.apiUrl=https://api.github.com
 ```
 > (Obviously change the above values to be your local GitHub Enterprise installation rather than the public URLs)
-4. When configuring Keycloak, you will now have two *GitHub* options when creating the Identity Provider. Instead of choosing *GitHub* (or *OpenID Connect v1.0*) instead choose **GitHub (Local)**.
+4. When configuring Keycloak, you will now have two *GitHub* options when creating the Identity Provider. Instead of choosing *GitHub* (or *OpenID Connect v1.0*) instead choose **GitHub Enterprise**.
 5. All other configuration is the same as documented for configuring public GitHub integration.
 
 The result of doing this is that you will be using a custom GitHub Identity provider implementation 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.apicurio</groupId>
     <artifactId>apicurio-keycloak-extensions</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>apicurio-keycloak-extensions</name>
 
@@ -85,8 +85,9 @@
         <version.scala-maven.plugin>4.0.1</version.scala-maven.plugin>
 
         <!-- Dependency Versions -->
-        <version.org.keycloak>7.0.1</version.org.keycloak>
         <version.com.fasterxml.jackson.core>2.9.8</version.com.fasterxml.jackson.core>
+        <version.jboss.logging>3.4.1.Final</version.jboss.logging>
+        <version.org.keycloak>9.0.3</version.org.keycloak>
     </properties>
 
     <dependencyManagement>
@@ -105,6 +106,11 @@
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-services</artifactId>
                 <version>${version.org.keycloak}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.jboss.logging}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/social/pom.xml
+++ b/social/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.apicurio</groupId>
         <artifactId>apicurio-keycloak-extensions</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>9.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>apicurio-keycloak-extensions-social</artifactId>
     <dependencies>
@@ -33,6 +33,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProvider.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProvider.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
- * A version of the GiHub identity provider that supports a local installation of GitHub Enterprise.
+ * A version of the GitHub identity provider that supports a local installation of GitHub Enterprise.
  * @author eric.wittmann@gmail.com
  */
 public class LocalGitHubIdentityProvider extends GitHubIdentityProvider {

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProvider.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProvider.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
- * A version of the GitLab identity provider that supports a local installation of GitHub.
+ * A version of the GiHub identity provider that supports a local installation of GitHub Enterprise.
  * @author eric.wittmann@gmail.com
  */
 public class LocalGitHubIdentityProvider extends GitHubIdentityProvider {

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
@@ -26,8 +26,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.social.github.GitHubIdentityProvider;
 
 /**
- * Provider factory for the local github identity provider.
- * 
+ * Provider factory for the local github Enterprise identity provider.
+ *
  * @author eric.wittmann@gmail.com
  */
 public class LocalGitHubIdentityProviderFactory

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
@@ -34,7 +34,7 @@ public class LocalGitHubIdentityProviderFactory
 
     @Override
     public String getName() {
-        return "GitHub (Local)";
+        return "GitHub Enterprise";
     }
 
     @Override   

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitHubIdentityProviderFactory.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.kc.ext.social;
 
+import org.jboss.logging.Logger;
+import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProviderFactory;
@@ -32,12 +34,14 @@ public class LocalGitHubIdentityProviderFactory
         extends AbstractIdentityProviderFactory<GitHubIdentityProvider>
         implements SocialIdentityProviderFactory<GitHubIdentityProvider> {
 
+    protected static final Logger logger = Logger.getLogger(LocalGitHubIdentityProviderFactory.class);
+
     @Override
     public String getName() {
         return "GitHub Enterprise";
     }
 
-    @Override   
+    @Override
     public GitHubIdentityProvider create(KeycloakSession session, IdentityProviderModel model) {
         return new LocalGitHubIdentityProvider(session, new OIDCIdentityProviderConfig(model));
     }
@@ -45,6 +49,48 @@ public class LocalGitHubIdentityProviderFactory
     @Override
     public String getId() {
         return "github";
+    }
+
+    @SuppressWarnings("unchecked") // safe b/c OAuth2IdentityProviderConfig does extend IdentityProviderModel
+    @Override
+    public <C extends IdentityProviderModel> C createConfig() {
+        OAuth2IdentityProviderConfig config = new OIDCIdentityProviderConfig();
+
+        // The Base URL: https://github.com
+        String baseUrl = config.getConfig().get("baseUrl");
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            baseUrl = System.getProperty("apicurio.hub.github.baseUrl");
+        }
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            baseUrl = "https://github.com";
+        }
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        logger.infov("GitHub Enterprise Base URL: {}",  baseUrl);
+
+        // The Base URL: https://api.github.com
+        String apiUrl = config.getConfig().get("apiUrl");
+        if (apiUrl == null || apiUrl.trim().isEmpty()) {
+            apiUrl = System.getProperty("apicurio.hub.github.apiUrl");
+        }
+        if (apiUrl == null || apiUrl.trim().isEmpty()) {
+            apiUrl = "https://api.github.com";
+        }
+        if (apiUrl.endsWith("/")) {
+            apiUrl = apiUrl.substring(0, apiUrl.length() - 1);
+        }
+        logger.infov("GitHub Enterprise API URL: {}", apiUrl);
+
+        String authUrl = baseUrl + LocalGitHubIdentityProvider.AUTH_FRAGMENT;
+        String tokenUrl = baseUrl + LocalGitHubIdentityProvider.TOKEN_FRAGMENT;
+        String profileUrl = apiUrl + LocalGitHubIdentityProvider.PROFILE_FRAGMENT;
+
+        config.setAuthorizationUrl(authUrl);
+        config.setTokenUrl(tokenUrl);
+        config.setUserInfoUrl(profileUrl);
+
+        return (C) config;
     }
 
 }

--- a/social/src/main/java/io/apicurio/kc/ext/social/LocalGitLabIdentityProviderFactory.java
+++ b/social/src/main/java/io/apicurio/kc/ext/social/LocalGitLabIdentityProviderFactory.java
@@ -31,4 +31,11 @@ public class LocalGitLabIdentityProviderFactory
         return "gitlab";
     }
 
+    @Override
+    public <C extends IdentityProviderModel> C createConfig() {
+        // TODO Issue #1
+        throw new UnsupportedOperationException("Code is not implemented. " +
+                "See https://github.com/Apicurio/apicurio-keycloak-extensions/issues/1");
+    }
+
 }


### PR DESCRIPTION
* Also change name from "GitHub (Local)" to "GitHub Enterprise"
* fixes #2 